### PR TITLE
Intermediate object file generation

### DIFF
--- a/include/link.h
+++ b/include/link.h
@@ -1,7 +1,10 @@
 
-
+/* #define DEBUG 1 */
 #define SECTION_ALIGNMENT 0x1000
 #define FILE_ALIGNMENT 0x200
+#define EMIT_DLL 1
+#define EMIT_OBJ 2
+#define EMIT_EXE 3
 
 #define GET_NAME(X,Y) (*(uint32_t*)X == 0) ? (char*) ((size_t)Y+*((uint32_t*)X+1)) : X->N.ShortName;
 
@@ -34,13 +37,15 @@ struct _SectionChain {
   // section_num
   void* data;
   SectionChain* next;
-  SectionChain* this;    
+  SectionChain* this;
   union {
     size_t num;
     IMAGE_SECTION_HEADER* p;
   };
   // pointer to object
-  ObjectChain* obj;  
+  ObjectChain* obj;
+  SymbolChain* sym_head;
+  SymbolChain* sym_tail;
 };
 
 // the role of object chain is to help symbol hash table to look-up
@@ -78,14 +83,24 @@ typedef struct __attribute__((__packed__)) _CoffReloc {
 } CoffReloc;
 
 typedef struct __attribute__((__packed__)) _CallbackArgIn {
-  size_t* virtual_address;
+  union {
+    size_t* virtual_address;
+    size_t* section_name;
+  };
   char* name;
   size_t* type;
+  uint32_t storage_class;
 } CallbackArgIn;
 
 struct _SymbolChain3 {
   SymbolChain3* next;
   SymbolChain3* this;
   char* name;
+  uint32_t ever;
 };
+
+/* typedef struct __attribute__((packed)) _PltCode { */
+/*   uint16_t code __attribute__((packed)); */
+/*   uint32_t data; */
+/* } PltCode __attribute__((packed)); */
 

--- a/src/core/link/hashtable.c
+++ b/src/core/link/hashtable.c
@@ -23,7 +23,78 @@ uint32_t elf_hash(const uint8_t* name) {
   return h;
 }
 
-void init_hashtable() {
+uint8_t isSqlite(uint64_t* p) {
+  printf("%p\n", *(p+1));
+  if (*p == 0x66206574694C5153 && *(p+1) == 0x00332074616D726F) {
+    return 1;
+  }
+  return 0;
+}
+
+void* get_next_table(uint8_t* p, char** name) {
+  /* printf("%p,%p\n",p + 0xd, *p + 0xd); */
+  uint8_t* strbegin = p + 0xd;
+  /* printf("%p,%p\n",p + 0x4, (*(p + 0x4) - 13)/ 2); */
+  uint8_t len = (*(p + 0x4) - 13)/ 2;
+  *(strbegin + len) = 0;
+  /* printf("%s\n", strbegin); */
+  *name = strbegin;
+  return p + *p + 2;
+}
+
+void* get_next_record(uint8_t* p, char** name) {
+  /* printf("%p,%p,%p\n",p + 0x5, *p,*(p + 0x5)); */
+  uint8_t* strbegin = p + 0x5;
+  uint8_t len = *p - 3;
+  uint8_t* a = __malloc(len + 1);
+  uint8_t* a1 = a;
+  uint8_t* _p = strbegin;
+  uint8_t i = 0;
+  for (;i < len;i++,_p++,a++) {
+    *a = *_p;
+  }
+  // uint8_t* _name = *name;
+  *name = a1;
+  // memcpy(strbegin, a, len);
+  /* printf("%p,%s,%d\n", a1,a1, len); */
+  return p + *p + 2;
+}
+
+void iterate_table(uint8_t* p) {
+  uint8_t* p1 = p;
+  // TODO :: https://www.sqlite.org/fileformat.html
+  // DataBaseHeader should be skipped.
+  p += 100;
+  // Probably, next is [1.6. B-tree Pages]
+  // The two-byte integer at offset 5 designates the start of the cell content area
+  p += 5;
+  printf("[%p]\n", *(uint16_t*)p);
+  void* t = p1 + (256 * *p + *(p+1));
+  uint8_t i = 0;
+  uint8_t* r;
+  uint8_t* r_begin;
+  char* table_name;
+  uint8_t* record_name;
+  for (;;i++) {
+    t = get_next_table(t, &table_name);
+    r = (p1 + 0x4000 - i * 0x1000);
+    r_begin = r;
+    r += 256 * *(r+5) + *(r+6);      
+    for (;;) {
+      r = get_next_record(r, &record_name);
+      printf("rec:tablee,%s,%s\n", record_name,table_name);
+      alloc_dynamic_symbol(record_name, table_name);
+      if (r_begin + 0x1000 <= r) {
+	break;
+      }
+    }
+    if (p1 + 0x1000 <= t) {
+      break;
+    }
+  }
+}
+
+void init_hashtable(char* fname) {
   
   HashTable.nbucket = 100;
   HashTable.nchain = 0;
@@ -35,9 +106,17 @@ void init_hashtable() {
   hashSize = DLLHashTable.nbucket*sizeof(void*);
   DLLHashTable.bucket = __malloc(hashSize);
   memset(DLLHashTable.bucket, 0, hashSize);
-  alloc_dynamic_symbol("ExitProcess","kernel32");
-  alloc_dynamic_symbol("GetStdHandle","kernel32");
-  alloc_dynamic_symbol("WriteFile","kernel32");  
+  uint8_t* p = alloc_file(fname);
+  printf("!!!!! :: %p,%p\n", p, *p);
+  if (isSqlite(p)) {
+    iterate_table(p);
+  } else {
+    alloc_dynamic_symbol("f1","ex65");
+    alloc_dynamic_symbol("ExitProcess","kernel32");
+    alloc_dynamic_symbol("GetStdHandle","kernel32");
+    alloc_dynamic_symbol("WriteFile","kernel32");
+    alloc_dynamic_symbol("MessageBoxA","user32");
+  }
 }
 
 

--- a/src/core/link/object.c
+++ b/src/core/link/object.c
@@ -24,9 +24,19 @@ void alloc_obj_chain(void* sym_begin, void* str_begin, uint32_t sym_num) {
   CurrentObject->str_table_p = str_begin;
   CurrentObject->symbol_num = sym_num;
   CurrentObject->section_chain_head = 0;
-  CurrentObject->section_chain_tail = 0;  
+  CurrentObject->section_chain_tail = 0;
   CurrentObject->next = 0;
 }
+
+void collect_symbol_from_obj() {
+  ObjectChain* oc = InitialObject;
+  for (;oc;oc=oc->next) {
+    printf("symtable p:%p\n", oc->symbol_table_p);
+    printf("sym num :%d\n", oc->symbol_num);    
+  }
+  return 0;
+}
+
 
 SectionChain* get_sc_from_obj(int index) {
   SectionChain* sc = CurrentObject->section_chain_head;
@@ -41,25 +51,26 @@ SectionChain* get_sc_from_obj(int index) {
 
 void* alloc_obj(char* fname) {
 
-  HANDLE hFile = CreateFile
-    (
-     fname, GENERIC_ALL/* | GENERIC_EXECUTE*/, 0, NULL,
-     OPEN_EXISTING/*CREATE_NEW*/, 0/*FILE_SHARE_READ*/, NULL
-     );
-  if (hFile == -1) {
-    printf("file not found\n");
-    return 0;
-  }
-  DWORD wReadSize;
-  DWORD size = GetFileSize(hFile , NULL);
-  if (size == -1) {
-    printf("cannot get file size\n");
-    return 0;
-  }
-  void* p = __malloc(size);
-  ReadFile(hFile, p, size, &wReadSize , NULL);
-  CloseHandle(hFile);
-  return p;
+  return alloc_file(fname);
+  /* HANDLE hFile = CreateFile */
+  /*   ( */
+  /*    fname, GENERIC_ALL/\* | GENERIC_EXECUTE*\/, 0, NULL, */
+  /*    OPEN_EXISTING/\*CREATE_NEW*\/, 0/\*FILE_SHARE_READ*\/, NULL */
+  /*    ); */
+  /* if (hFile == -1) { */
+  /*   printf("file not found\n"); */
+  /*   return 0; */
+  /* } */
+  /* DWORD wReadSize; */
+  /* DWORD size = GetFileSize(hFile , NULL); */
+  /* if (size == -1) { */
+  /*   printf("cannot get file size\n"); */
+  /*   return 0; */
+  /* } */
+  /* void* p = __malloc(size); */
+  /* ReadFile(hFile, p, size, &wReadSize , NULL); */
+  /* CloseHandle(hFile); */
+  /* return p; */
 }
 
 

--- a/src/core/link/reloc.c
+++ b/src/core/link/reloc.c
@@ -15,6 +15,7 @@ extern uint32_t PltBegin;
 extern uint32_t PltOffset;
 extern uint8_t _Win32;
 extern uint64_t ImageBase;
+extern uint8_t EmitType;
 
 void wrapper_f(void* arg1, void* arg2, void* f) {
   callback_arg3(arg1,arg2,f);
@@ -26,15 +27,13 @@ void do_reloc(void* f) {
   ObjectChain* oc1;
   IMAGE_SYMBOL* is1;
   IMAGE_SECTION_HEADER* ish;
-  int i = 0;
   CoffReloc* reloc;
   CallbackArgIn arg;
   uint32_t* addr;
   char* name;
+  int i = 0;
   for (;sec1;sec1=sec1->next) {
-    printf("sec1:%p\n",sec1);
     for (sec2=sec1->this;sec2;sec2=sec2->this) {
-      printf("sec2:%p,%s\n",sec2, sec2->p->Name);
       if (ish=sec2->p) {
 	reloc = ish->PointerToRelocations;
 	oc1 = sec2->obj;
@@ -42,30 +41,66 @@ void do_reloc(void* f) {
 	  is1 = oc1->symbol_table_p + reloc->SymbolTableIndex;
 	  name = GET_NAME(is1, oc1->str_table_p);
 	  arg.name = name;
-	  arg.virtual_address = ish->VirtualAddress + reloc->VirtualAddress;
+	  // virtual address points to the head of address not the tail.
+	  if (EmitType != EMIT_OBJ) {
+	    arg.virtual_address = ish->VirtualAddress + reloc->VirtualAddress;
+	  } else {
+	    arg.section_name = sec2->p->Name;
+	  }
 	  arg.type = reloc->Type;
 	  arg.storage_class = is1->StorageClass;
-	  if (is1->StorageClass == 3/*Static*/) {
-	    printf("name:%s,%p,%p\n", name,sec1, sec1->this);
-	    SectionChain* sc = get_section_chain_from_name(name);
-	    // sc->p->VirtualAddress;
-	    // arg.dst_virtual_address = sc->p->VirtualAddress + is1->Value;
-	    if (sc) {
-	    printf("storage class static !%p,%s,%p,%p\n",
-	    	   sc->p->VirtualAddress,
-	    	   arg.name,is1->Value,is1->StorageClass);
-	    } else {
-	      printf("sc:%p\n", sc);
-	    }
-	  }
 	  addr = sec2->data + reloc->VirtualAddress;
-	  if (*addr) {
-	    printf("applied to!!\n");
-	  }
 	  // call wrapper function of callback
 	  wrapper_f(&arg,addr,f);
+	  printf("n:%s\n", name);
 	}
       }
+    }
+  }
+}
+
+void fill_address(uint32_t* addr, uint16_t type, uint32_t dst_vaddr, uint32_t src_vaddr) {
+  switch (type) {
+  case IMAGE_REL_AMD64_ADDR64/*1*/:
+    *(uint64_t*)addr += ImageBase + dst_vaddr;
+    break;
+  case IMAGE_REL_AMD64_ADDR32/*2*/:
+    *addr += ImageBase + dst_vaddr;
+    break;
+  case IMAGE_REL_AMD64_ADDR32NB/*3*/:
+    *addr += dst_vaddr;
+    break;
+  case IMAGE_REL_AMD64_REL32/*4*/:
+    *addr += dst_vaddr - (src_vaddr + 4);
+    break;
+  case IMAGE_REL_AMD64_REL32 | IMAGE_REL_AMD64_SSPAN32:
+    *addr += dst_vaddr - (src_vaddr + 4);
+    break;
+  default:
+    printf("not supported type\n");
+    break;
+    // case 5 to 9 is REL32_1 to REL32_5
+    // from A to F, they are somehow special.
+    // IMAGE_REL_AMD64_SECTION
+    // (0x10)IMAGE_REL_AMD64_SSPAN32
+  }
+}
+
+void resolve_only_in_a_section(CallbackArgIn* _in, uint32_t* addr) {
+  char* name = _in->name;
+  uint16_t type = _in->type;
+  if (type == IMAGE_REL_AMD64_REL32) {
+    ObjectChain* oc = 0;
+    IMAGE_SYMBOL* is = lookup_symbol(name, &oc);
+    if (is) {
+      char* export_section_name = get_section_name(is, oc);
+      if (!strcmp(export_section_name, _in->section_name)) {
+	printf("within a section\n");
+	logger_emit("relocation:resolved on another file\n");
+	size_t* export_address = get_export_virtual_address(is, oc);
+	fill_address(addr, type, export_address, _in->virtual_address);      
+      }
+      return;
     }
   }
 }
@@ -73,57 +108,59 @@ void do_reloc(void* f) {
 void resolve(CallbackArgIn* _in,uint32_t* addr) {
   char* name = _in->name;
   uint16_t type = _in->type;
-  size_t* export_address = 0;
-  // 1st, you should check symbols on the same object.  
+  // 1st, you should check symbols on the same object.
+  // If storage class is static, it is likely that ADDR64/ADDR32 which
+  // requires to fill virtual address + ImageBase on it directly.
   if (_in->storage_class == 3/*Static*/) {
     SectionChain* sc = get_section_chain_from_name(name);
-    *addr += sc->p->VirtualAddress;
-    if (_Win32) {
-      *addr += ImageBase;
-    }
+    fill_address(addr, type, sc->p->VirtualAddress, _in->virtual_address);
+    logger_emit("relocation:resolved on a same file(StorageClass==3)\n");    
     return;
   }
-  IMAGE_SYMBOL* ret = lookup_symbol(name, &export_address);  
-  if (ret) {
-    printf("callback called,%s,%d,%p,%d,%d,%p(!%x),%p\n",
-	   name, type,ret,ret->SectionNumber,ret->Value,addr,
-	   *(uint64_t*)addr,export_address);
-    if (type == IMAGE_REL_AMD64_ADDR32)
-      *addr = export_address;
-    else if
-      (type == IMAGE_REL_AMD64_REL32 ||
-       type == IMAGE_REL_AMD64_REL32 | IMAGE_REL_AMD64_SSPAN32) {
-      *addr = (uint32_t)export_address - ((uint32_t)_in->virtual_address + 4);
-    } else {
-      printf("unknown type:%p,%p\n",type,IMAGE_REL_AMD64_SREL32);
-    }
-  } else {
-    printf("type:%p\n",type);
-    char* dllname = lookup_dynamic_symbol(name, 1);
-    if (dllname) {
-      // PltOffset(0xff 0x25 0x00 0x00 0x00 0x00) - (addr + 1)(just after call)
-      *addr = ((uint8_t*)PltOffset - (uint8_t*)_in->virtual_address) - 4;
-      PltOffset += 6;
-      void* new = add_dynamic_resolved_entry(name, dllname, addr);
-      if (new) {
-	if (ImportDirectoryLen == 0) {
-	  // if it is 1st ever insertion of IID, you need to set an empty one
-	  // at the end of it.
-	  ImportDirectoryLen += sizeof(IMAGE_IMPORT_DESCRIPTOR);
-	}
-	ImportDirectoryLen += sizeof(IMAGE_IMPORT_DESCRIPTOR) + 1 + strlen(dllname);
-	// needs empty image_thunk_data at the end of it for indicating its end.
-	ImportDirectoryLen += 2 * sizeof(void*/*IMAGE_THUNK_DATA*/);
-      }
-      // 1entry = (IAT) + (INT) + HINT + strlen + NULL
-      ImportDirectoryLen += 2 * sizeof(void*/*IMAGE_THUNK_DATA*/) + 2 + strlen(name) + 1;
-      printf("%s was resolved on %s\n", name, dllname);
-    } else {
-      printf("could not resolved.. \n");
-    }
-    // if you could not resolve, it will be re-evaluated with the dynamic loader at 2nd stage.
-    // Dynamic loader
+  ObjectChain* oc = 0;
+  IMAGE_SYMBOL* is = lookup_symbol(name, &oc);
+  if (is) {
+    size_t* export_address = get_export_virtual_address(is, oc);
+    logger_emit("relocation:resolved on another file\n");
+    /* printf("callback called,%s,%d,%p,%d,%d,%p(!%x),%p,%p\n", */
+    /* 	   name, type,ret,ret->SectionNumber,ret->Value,addr, */
+    /* 	   *(uint64_t*)addr,export_address, _in->virtual_address); */
+    fill_address(addr, type, export_address, _in->virtual_address);
+    return;
   }
+  uint32_t ever = 0;
+  char* dllname = lookup_dynamic_symbol(name, 1, &ever);
+  if (!dllname) {
+    fprintf(stdout, "could not resolved..%s \n", name);
+    return;
+  }
+  logger_emit("relocation:resolved on an entry of a dyanmic dll\n");
+  // printf("ever:%p\n", ever);
+  // PltOffset(0xff 0x25 0x00 0x00 0x00 0x00) - (addr + 1)(just after call)
+  if (ever) {
+    fill_address(addr, type, ever, _in->virtual_address);
+    // *addr = ever - (uint32_t)_in->virtual_address - 4;
+    printf("do not need to add new import entry.\n");
+    return;
+  }
+  fill_address(addr, type, PltOffset, _in->virtual_address);
+  // *addr = PltOffset - (uint32_t)_in->virtual_address - 4;	
+  PltOffset += 6;
+  void* new = add_dynamic_resolved_entry(name, dllname, addr);
+  if (new) {
+    // printf("new!,%p,%p,%p\n", addr,*addr, *(addr-1));
+    if (ImportDirectoryLen == 0) {
+      // if it is 1st ever insertion of IID, you need to set an empty one
+      // at the end of it.
+      ImportDirectoryLen += sizeof(IMAGE_IMPORT_DESCRIPTOR);
+    }
+    ImportDirectoryLen += sizeof(IMAGE_IMPORT_DESCRIPTOR) + 1 + strlen(dllname);
+    // needs empty image_thunk_data at the end of it for indicating its end.
+    ImportDirectoryLen += 2 * sizeof(void*/*IMAGE_THUNK_DATA*/);
+  }
+  // 1entry = (IAT) + (INT) + HINT + strlen + NULL
+  ImportDirectoryLen += 2 * sizeof(void*/*IMAGE_THUNK_DATA*/) + 2 + strlen(name) + 1;
+  printf("%s was resolved on %s\n", name, dllname);
 }
 
 


### PR DESCRIPTION
To support incremental linking, merging two or more object files should generate .obj not only .exe or .dll.
Resolution will be done only in a section which are supposed to be merged.

This pull request contains some not-related bug fixes. 